### PR TITLE
Improved documentation for Copernicus provider and account manager

### DIFF
--- a/docs/source/examples.rst
+++ b/docs/source/examples.rst
@@ -23,4 +23,5 @@ Examples
    :maxdepth: 2
    :caption: Additional functionality
 
+   notebooks/products/account_manager.ipynb
    notebooks/products/catalogue.ipynb

--- a/docs/source/notebooks/products/account_manager.ipynb
+++ b/docs/source/notebooks/products/account_manager.ipynb
@@ -1,0 +1,1 @@
+../../../../notebooks/products/account_manager.ipynb

--- a/notebooks/commandlinetool.ipynb
+++ b/notebooks/commandlinetool.ipynb
@@ -194,7 +194,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.6.11"
   }
  },
  "nbformat": 4,

--- a/notebooks/products/account_manager.ipynb
+++ b/notebooks/products/account_manager.ipynb
@@ -1,0 +1,192 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "241dd64a",
+   "metadata": {},
+   "source": [
+    "# Adding and modifying user accounts \n",
+    "\n",
+    "\n",
+    "Before you can download data, you need to create a user account for the respective [data provider](https://pansat.readthedocs.io/en/latest/download/providers.html) and add your account information using the [Pansat account manager](https://pansat.readthedocs.io/en/latest/download/accounts.html#accounts). Here is an example for how you add an account, check your account info and delete an account. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "e5965302",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pansat.download.accounts import add_identity, get_identity, delete_identity"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "422b4e0f",
+   "metadata": {},
+   "source": [
+    "Let's say that you have created an account for the data provider [Icare](https://pansat.readthedocs.io/en/latest/download/providers/icare.html) with "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "id": "3239bf3c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "username = 'Fritzi'\n",
+    "password = 'LattSomEnPlatt12345!'"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "a2a9abd9",
+   "metadata": {},
+   "source": [
+    "**Add your account info**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "id": "5734fb11",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please enter password for provider 'Icare' and username 'Fritzi':\n",
+      "········\n"
+     ]
+    }
+   ],
+   "source": [
+    "add_identity('Icare', username)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d7af453a",
+   "metadata": {},
+   "source": [
+    "Note that for [Copernicus](https://pansat.readthedocs.io/en/latest/download/providers/copernicus.html), you need to install a key and API client following the steps in  https://cds.climate.copernicus.eu/api-how-to. This means that in addition to your username and password, you will have a *url* and *key* stored in *$HOME/.cdsapirc*. For this data provider simply use the *url* and *key*, instead of *username* and *password*: \n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "id": "dd388dd5",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Please enter the key for provider 'Copernicus' with url 'https://cds.climate.copernicus.eu/api/v2':\n",
+      "········\n"
+     ]
+    }
+   ],
+   "source": [
+    "url = 'https://cds.climate.copernicus.eu/api/v2'\n",
+    "key = '{uid}:{api-key}'\n",
+    "\n",
+    "add_identity('Copernicus', url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "93b1ac06",
+   "metadata": {},
+   "source": [
+    "**You can then check if your account info has been successfully stored in the encrypted identities.json**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "id": "e9c7a0b0",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('Fritzi', \"'LattSomEnPlatt12345!'\")"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_identity('Icare')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "id": "622e042b",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "('https://cds.climate.copernicus.eu/api/v2', \"'{uid}:{api-key}'\")"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "get_identity('Copernicus')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "78740beb",
+   "metadata": {},
+   "source": [
+    "Note that your account info will be overwritten if you add an account with an existing username for a certain provider. \n",
+    "\n",
+    "**To delete your account info again, use:**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "id": "0c73e3d2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "delete_identity('Copernicus')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/notebooks/products/era5.ipynb
+++ b/notebooks/products/era5.ipynb
@@ -599,7 +599,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
@@ -613,7 +613,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.11"
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,

--- a/pansat/download/accounts.py
+++ b/pansat/download/accounts.py
@@ -241,13 +241,16 @@ def add_identity(provider, user_name):
     if not _PANSAT_SECRET:
         authenticate()
 
-    if provider == 'Copernicus':
-        print( f"Please enter the key for provider '{provider}' with url"
-        f" '{user_name}':")
+    if provider == "Copernicus":
+        print(
+            f"Please enter the key for provider '{provider}' with url"
+            f" '{user_name}':"
+        )
     else:
         print(
-        f"Please enter password for provider '{provider}' and username"
-        f" '{user_name}':")
+            f"Please enter password for provider '{provider}' and username"
+            f" '{user_name}':"
+        )
     password = getpass.getpass()
     password_encrypted = encrypt(password)
     user_name_encrypted = encrypt(user_name)

--- a/pansat/download/accounts.py
+++ b/pansat/download/accounts.py
@@ -235,13 +235,19 @@ def add_identity(provider, user_name):
         provider(``str``): Name of the data provider class for which the user
             name is valid.
         user(``str``): User name for the data provider.
+                       ! Note that for Copernicus,you have to use the url from your $HOME/.cdsapirc
+                         For more info: https://cds.climate.copernicus.eu/api-how-to
     """
     if not _PANSAT_SECRET:
         authenticate()
-    print(
+
+    if provider == 'Copernicus':
+        print( f"Please enter the key for provider '{provider}' with url"
+        f" '{user_name}':")
+    else:
+        print(
         f"Please enter password for provider '{provider}' and username"
-        f" '{user_name}':"
-    )
+        f" '{user_name}':")
     password = getpass.getpass()
     password_encrypted = encrypt(password)
     user_name_encrypted = encrypt(user_name)

--- a/pansat/download/providers/copernicus.py
+++ b/pansat/download/providers/copernicus.py
@@ -4,6 +4,8 @@ pansat.download.providers.copernicus
 
 This module provides the ``CopernicusProvider`` class to download data from the
 `Copernicus data store <https://cds.climate.copernicus.eu/cdsapp#!/home>`_.
+After creating an account, you need to install a key for the CDS API and the python library cdsapi
+following these steps: https://cds.climate.copernicus.eu/api-how-to
 """
 
 import logging


### PR DESCRIPTION
This PR contains 
- a new example notebook for our [read the docs page](https://pansat.readthedocs.io/en/latest/) explainig how to add and modify account info
- improved docstrings for `pansat.download.accounts.add_identity()` and  `pansat.download.providers.copernicus.py` to clarify that for the Copernicus provider you need to store information on the *key* and *url* for the CDS API key, whereas all other providers store the username and password.


* [ ] Have you added unit tests for the new functionality?
* [x] Have all tests passed in your local clone?
* [x] Have you written documentation that is easy to understand?
* [x] Have you added an example?
* [x] Has the formatting of your code been checked?
