### PR TITLE
Gpm 2 bcmb 07 variables

### DIFF
--- a/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
+++ b/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
@@ -18,17 +18,14 @@ type = coordinate
 name = KuGMI/Latitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
-description = "The earth latitude of the center of the IFOV at the altitude of the earth ellipsiod. Latitude
-is positive north, negative south. Missing value as -9999.9"
+description = "The earth latitude of the center of the IFOV at the altitude of the earth ellipsiod. Latitude is positive north, negative south. Missing value as -9999.9"
 
 [Longitude]
 type = coordinate
 name = KuGMI/Longitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
-description = "The earth longitude of the center of the IFOV at the altitude of the earth ellipsiod.
-Longitude is positive east, negative west. A point on the 180th meridian has the value
--180 degrees. Missing value as -9999.9"
+description = "The earth longitude of the center of the IFOV at the altitude of the earth ellipsiod. Longitude is positive east, negative west. A point on the 180th meridian has the value -180 degrees. Missing value as -9999.9"
 
 [estimSurfPrecipTotRate]
 type = variable

--- a/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
+++ b/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
@@ -13,26 +13,31 @@ type = dimension
 [matched_pixels]
 type = dimension
 
-[latitude]
+[Latitude]
 type = coordinate
 name = KuGMI/Latitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
+description = "The earth latitude of the center of the IFOV at the altitude of the earth ellipsiod. Latitude
+is positive north, negative south. Missing value as -9999.9"
 
-[longitude]
+[Longitude]
 type = coordinate
 name = KuGMI/Longitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
+description = "The earth longitude of the center of the IFOV at the altitude of the earth ellipsiod.
+Longitude is positive east, negative west. A point on the 180th meridian has the value
+-180 degrees. Missing value as -9999.9"
 
-[surface_precipitation]
+[estimSurfPrecipTotRate]
 type = variable
 name = KuGMI/estimSurfPrecipTotRate
 unit = mm/h
 dimensions = ["matched_scans", "matched_pixels"]
 description = "Estimated surface total precip rate (from lowest clutter-free bin). Missing values as -9999.9"
 
-[surface_precipitation_sigma]
+[estimSurfPrecipTotRateSigma]
 type = variable
 name = KuGMI/estimSurfPrecipTotRateSigma
 unit = mm/h
@@ -44,3 +49,50 @@ type = variable
 name = KuGMI/ScanTime
 callback = _extract_scantime
 dimensions = ["scans"]
+
+[lowestUnclutteredBin]
+type = variable
+name = KuGMI/lowestUnclutteredBin
+dimensions = ["matched_scans", "matched_pixels"]
+description = "Lowest clutter free bin. Missing values as -9999"
+
+[lowestEstimateBin]
+type = variable
+name = KuGMI/lowestEstimateBin
+dimensions = ["matched_scans", "matched_pixels"]
+description = "Lowest bin for estimated precipitation. Missing values as -9999"
+
+[multiScatMaxContrib]
+type = variable
+name = KuGMI/multiScatMaxContrib
+dimensions = ["matched_scans", "matched_pixels"]
+unit = dB
+description = "Maximum contribution, in a given radar profile, by multiple scattering to the simulated reflectivity. Missing values as -9999.9"
+
+[nearSurfPrecipTotRate]
+type = variable
+name = KuGMI/nearSurfPrecipTotRate
+dimensions = ["matched_scans", "matched_pixels"]
+unit = mm/h
+description = "Near-surface total precip rate (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
+
+[nearSurfPrecipTotRateSigma]
+type = variable
+name = KuGMI/nearSurfPrecipTotRateSigma
+dimensions = ["matched_scans", "matched_pixels"]
+unit = mm/h
+description = "Near-surface total precip rate uncertainty (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
+
+[nearSurfPrecipLiqRate]
+type = variable
+name = KuGMI/nearSurfPrecipLiqRate
+dimensions = ["matched_scans", "matched_pixels"]
+unit = mm/h
+description = "Near-surface liquid precip rate (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
+
+[estimSurfPrecipLiqRate]
+type = variable
+name = KuGMI/estimSurfPrecipLiqRate
+dimensions = ["matched_scans", "matched_pixels"]
+unit = mm/h
+description = "Estimated surface liquid precip rate (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"

--- a/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
+++ b/pansat/products/satellite/gpm/l2b_gpm_cmb.ini
@@ -13,28 +13,28 @@ type = dimension
 [matched_pixels]
 type = dimension
 
-[Latitude]
+[latitude]
 type = coordinate
 name = KuGMI/Latitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
 description = "The earth latitude of the center of the IFOV at the altitude of the earth ellipsiod. Latitude is positive north, negative south. Missing value as -9999.9"
 
-[Longitude]
+[longitude]
 type = coordinate
 name = KuGMI/Longitude
 unit = degree
 dimensions = ["matched_scans", "matched_pixels"]
 description = "The earth longitude of the center of the IFOV at the altitude of the earth ellipsiod. Longitude is positive east, negative west. A point on the 180th meridian has the value -180 degrees. Missing value as -9999.9"
 
-[estimSurfPrecipTotRate]
+[estim_surf_precip_tot_rate]
 type = variable
 name = KuGMI/estimSurfPrecipTotRate
 unit = mm/h
 dimensions = ["matched_scans", "matched_pixels"]
 description = "Estimated surface total precip rate (from lowest clutter-free bin). Missing values as -9999.9"
 
-[estimSurfPrecipTotRateSigma]
+[estim_surf_precip_tot_rate_sigma]
 type = variable
 name = KuGMI/estimSurfPrecipTotRateSigma
 unit = mm/h
@@ -47,47 +47,47 @@ name = KuGMI/ScanTime
 callback = _extract_scantime
 dimensions = ["scans"]
 
-[lowestUnclutteredBin]
+[lowest_uncluttered_bin]
 type = variable
 name = KuGMI/lowestUnclutteredBin
 dimensions = ["matched_scans", "matched_pixels"]
 description = "Lowest clutter free bin. Missing values as -9999"
 
-[lowestEstimateBin]
+[lowest_estimate_bin]
 type = variable
 name = KuGMI/lowestEstimateBin
 dimensions = ["matched_scans", "matched_pixels"]
 description = "Lowest bin for estimated precipitation. Missing values as -9999"
 
-[multiScatMaxContrib]
+[multi_scat_max_contrib]
 type = variable
 name = KuGMI/multiScatMaxContrib
 dimensions = ["matched_scans", "matched_pixels"]
 unit = dB
 description = "Maximum contribution, in a given radar profile, by multiple scattering to the simulated reflectivity. Missing values as -9999.9"
 
-[nearSurfPrecipTotRate]
+[near_surf_precip_tot_rate]
 type = variable
 name = KuGMI/nearSurfPrecipTotRate
 dimensions = ["matched_scans", "matched_pixels"]
 unit = mm/h
 description = "Near-surface total precip rate (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
 
-[nearSurfPrecipTotRateSigma]
+[near_surf_precip_tot_rate_sigma]
 type = variable
 name = KuGMI/nearSurfPrecipTotRateSigma
 dimensions = ["matched_scans", "matched_pixels"]
 unit = mm/h
 description = "Near-surface total precip rate uncertainty (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
 
-[nearSurfPrecipLiqRate]
+[near_surf_precip_liq_rate]
 type = variable
 name = KuGMI/nearSurfPrecipLiqRate
 dimensions = ["matched_scans", "matched_pixels"]
 unit = mm/h
 description = "Near-surface liquid precip rate (from lowest clutter-free bin). Values range from 0 to 300 mm/h. Missing values as -9999.9"
 
-[estimSurfPrecipLiqRate]
+[estim_surf_precip_liq_rate]
 type = variable
 name = KuGMI/estimSurfPrecipLiqRate
 dimensions = ["matched_scans", "matched_pixels"]


### PR DESCRIPTION
Adapted the configuration file to follow the variable names and descriptions in the GPM 2BCMB V07 file specification documentation (https://disc.gsfc.nasa.gov/datasets/GPM_2BCMB_07/summary, [FILE SPECIFICATION DOCUMENT](https://gpmweb2https.pps.eosdis.nasa.gov/pub/stout/helpdesk/filespec.GPM.V7.pdf))